### PR TITLE
fix: Do not cancel other jobs on fail in `default-build.yml`

### DIFF
--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -21,6 +21,7 @@ jobs:
       id-token: write
     uses: ./.github/workflows/docker-publish.yml
     strategy:
+      fail-fast: false
       matrix:
         # TODO: Periodically check https://gazebosim.org/docs/latest/ros_installation/#summary-of-compatible-ros-and-gazebo-combinations and update non-EOL recommended combinations
         include:


### PR DESCRIPTION
This is an emergency hot fix to ensure a successfully pushed docker image onto the git hub repository. 