### PR TITLE
Correctly passthrough `WEBSOCKET_GZLAUNCH_FILE` in Github Actions.

### DIFF
--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -45,4 +45,4 @@ jobs:
       ubuntu_distro: ${{ matrix.ubuntu_distro }}
       ros_distro: ${{ matrix.ros_distro }}
       gz_version: ${{ matrix.gz_version }}
-      websocket_gzlaunch_file: ${{ matrix.websocket.gzlaunch_file }}
+      websocket_gzlaunch_file: ${{ matrix.websocket_gzlaunch_file }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -154,13 +154,12 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ inputs.ubuntu_distro }}-${{ inputs.platform }} # From https://github.com/docker/build-push-action/issues/286#issuecomment-893253003
           cache-to: type=gha,mode=max,scope=${{ inputs.ubuntu_distro }}-${{ inputs.platform }}
-          platforms: ${{ inputs.platform }}
           build-args: |
             UBUNTU_DISTRO=${{ inputs.ubuntu_distro }}
             ROS_DISTRO=${{ inputs.ros_distro }}
             GZ_VERSION=${{ inputs.gz_version }} 
             WEBSOCKET_GZLAUNCH_FILE=${{ inputs.websocket_gzlaunch_file }}
-          
+          platforms: ${{ inputs.platform }}
 
       # Sign the resulting Docker image digest if pushed to release branch
       # This will only write to the public Rekor transparency log when the Docker


### PR DESCRIPTION
As mentioned in #18, the `WEBSOCKET_GZLAUNCH_FILE` build-args parameter was empty during the build process. This PR aims to ensure this argument is correctly assigned during build. This can be confirmed by looking at the build command for each job under `Build and push Docker image` action in the [`checks`](https://github.com/agape-1/docker-ros2-kasmvnc/pull/21/checks) section.