### PR TITLE
Post release fixes and publish arm64

### DIFF
--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -45,4 +45,4 @@ jobs:
       ubuntu_distro: ${{ matrix.ubuntu_distro }}
       ros_distro: ${{ matrix.ros_distro }}
       gz_version: ${{ matrix.gz_version }}
-      websocket_gzlaunch_file: ${{ matrix.websocket.gzlaunch_file }}
+      websocket_gzlaunch_file: ${{ matrix.websocket_gzlaunch_file }}

--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -23,6 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        platforms: ['linux/amd64', 'linux/arm64']
         # TODO: Periodically check https://gazebosim.org/docs/latest/ros_installation/#summary-of-compatible-ros-and-gazebo-combinations and update non-EOL recommended combinations
         include:
           - ubuntu_distro: jammy
@@ -46,3 +47,4 @@ jobs:
       ros_distro: ${{ matrix.ros_distro }}
       gz_version: ${{ matrix.gz_version }}
       websocket_gzlaunch_file: ${{ matrix.websocket_gzlaunch_file }}
+      platform: ${{ matrix.platforms }}

--- a/.github/workflows/default-build.yml
+++ b/.github/workflows/default-build.yml
@@ -23,25 +23,49 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platforms: ['linux/amd64', 'linux/arm64']
         # TODO: Periodically check https://gazebosim.org/docs/latest/ros_installation/#summary-of-compatible-ros-and-gazebo-combinations and update non-EOL recommended combinations
         include:
-          - ubuntu_distro: jammy
+          - platform: linux/amd64
+            ubuntu_distro: jammy
             ros_distro: iron
             gz_version: fortress
             websocket_gzlaunch_file: websocket.ign
-          - ubuntu_distro: jammy
+          - platform: linux/arm64
+            ubuntu_distro: jammy
+            ros_distro: iron
+            gz_version: fortress
+            websocket_gzlaunch_file: websocket.ign
+          - platform: linux/amd64
+            ubuntu_distro: jammy
             ros_distro: humble
             gz_version: fortress
             websocket_gzlaunch_file: websocket.ign
-          - ubuntu_distro: noble
+          - platform: linux/arm64
+            ubuntu_distro: jammy
+            ros_distro: humble
+            gz_version: fortress
+            websocket_gzlaunch_file: websocket.ign
+          - platform: linux/amd64
+            ubuntu_distro: noble
             ros_distro: jazzy
             gz_version: harmonic
             websocket_gzlaunch_file: websocket.gzlaunch
-          - ubuntu_distro: noble
+          - platform: linux/arm64
+            ubuntu_distro: noble
+            ros_distro: jazzy
+            gz_version: harmonic
+            websocket_gzlaunch_file: websocket.gzlaunch
+          - platform: linux/amd64
+            ubuntu_distro: noble
             ros_distro: rolling
             gz_version: ionic
             websocket_gzlaunch_file: websocket.gzlaunch
+          - platform: linux/arm64
+            ubuntu_distro: noble
+            ros_distro: rolling
+            gz_version: ionic
+            websocket_gzlaunch_file: websocket.gzlaunch
+  
     with: 
       ubuntu_distro: ${{ matrix.ubuntu_distro }}
       ros_distro: ${{ matrix.ros_distro }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -154,13 +154,12 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ inputs.ubuntu_distro }}-${{ inputs.platform }} # From https://github.com/docker/build-push-action/issues/286#issuecomment-893253003
           cache-to: type=gha,mode=max,scope=${{ inputs.ubuntu_distro }}-${{ inputs.platform }}
-          platforms: ${{ inputs.platform }}
           build-args: |
             UBUNTU_DISTRO=${{ inputs.ubuntu_distro }}
             ROS_DISTRO=${{ inputs.ros_distro }}
             GZ_VERSION=${{ inputs.gz_version }} 
             WEBSOCKET_GZLAUNCH_FILE=${{ inputs.websocket_gzlaunch_file }}
-          
+          platforms: ${{ inputs.platform }}
 
       # Sign the resulting Docker image digest if pushed to release branch
       # This will only write to the public Rekor transparency log when the Docker


### PR DESCRIPTION
This PR fixes an incorrect launch file in the published docker images, which should now allow the images to automatically start Gazebo. Additionally, changes have been made to automatically publish arm64 build variants of the image. 